### PR TITLE
Change the partition key order for capten_cluster table

### DIFF
--- a/server/pkg/agent/agent_handler.go
+++ b/server/pkg/agent/agent_handler.go
@@ -54,13 +54,13 @@ func (s *AgentHandler) UpdateAgent(clusterID string, agentCfg *Config) error {
 	return s.AddAgent(clusterID, agentCfg)
 }
 
-func (s *AgentHandler) GetAgent(clusterID string) (*Agent, error) {
+func (s *AgentHandler) GetAgent(orgId, clusterID string) (*Agent, error) {
 	agent := s.getAgent(clusterID)
 	if agent != nil {
 		return agent, nil
 	}
 
-	cfg, err := s.getAgentConfig(clusterID)
+	cfg, err := s.getAgentConfig(orgId, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -117,10 +117,10 @@ func (s *AgentHandler) Close() {
 	}
 }
 
-func (s *AgentHandler) getAgentConfig(clusterID string) (*Config, error) {
+func (s *AgentHandler) getAgentConfig(orgId, clusterID string) (*Config, error) {
 	agentCfg := &Config{}
 
-	clusterDetail, err := s.serverStore.GetClusterDetails(clusterID)
+	clusterDetail, err := s.serverStore.GetClusterDetails(orgId, clusterID)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to get cluster")
 	}

--- a/server/pkg/api/cluster_apps.go
+++ b/server/pkg/api/cluster_apps.go
@@ -62,7 +62,7 @@ func (s *Server) GetClusterApps(ctx context.Context, request *serverpb.GetCluste
 	}
 	s.log.Infof("[org: %s] GetClusterApps request recieved for cluster %s", orgId, request.ClusterID)
 
-	a, err := s.agentHandeler.GetAgent(request.ClusterID)
+	a, err := s.agentHandeler.GetAgent(orgId, request.ClusterID)
 	if err != nil {
 		s.log.Error("failed to connect to agent", err)
 		return &serverpb.GetClusterAppsResponse{Status: serverpb.StatusCode_INTERNRAL_ERROR,
@@ -95,7 +95,7 @@ func (s *Server) GetClusterAppLaunchConfigs(ctx context.Context, request *server
 	}
 
 	s.log.Infof("[org: %s] GetClusterAppLaunchConfigs request recieved for cluster %s", orgId, request.ClusterID)
-	a, err := s.agentHandeler.GetAgent(request.ClusterID)
+	a, err := s.agentHandeler.GetAgent(orgId, request.ClusterID)
 	if err != nil {
 		s.log.Error("failed to connect to agent", err)
 		return &serverpb.GetClusterAppLaunchConfigsResponse{Status: serverpb.StatusCode_INTERNRAL_ERROR,
@@ -120,8 +120,8 @@ func (s *Server) GetClusterApp(ctx context.Context, request *serverpb.GetCluster
 	return &serverpb.GetClusterAppResponse{}, nil
 }
 
-func (s *Server) configureSSOForClusterApps(ctx context.Context, clusterID string) error {
-	agentClient, err := s.agentHandeler.GetAgent(clusterID)
+func (s *Server) configureSSOForClusterApps(ctx context.Context, orgId, clusterID string) error {
+	agentClient, err := s.agentHandeler.GetAgent(orgId, clusterID)
 	if err != nil {
 		return errors.WithMessagef(err, "failed to get agent for cluster %s", clusterID)
 	}

--- a/server/pkg/api/cluster_registration.go
+++ b/server/pkg/api/cluster_registration.go
@@ -71,7 +71,7 @@ func (s *Server) NewClusterRegistration(ctx context.Context, request *serverpb.N
 	}
 
 	if s.cfg.RegisterLaunchAppsConifg {
-		if err := s.configureSSOForClusterApps(ctx, clusterID); err != nil {
+		if err := s.configureSSOForClusterApps(ctx, orgId, clusterID); err != nil {
 			s.log.Errorf("[org: %s] %v", orgId, err)
 			return &serverpb.NewClusterRegistrationResponse{
 				Status:        serverpb.StatusCode_INTERNRAL_ERROR,
@@ -218,7 +218,7 @@ func (s *Server) GetClusters(ctx context.Context, request *serverpb.GetClustersR
 	var data []*serverpb.ClusterInfo
 	for _, cluster := range clusterDetails {
 		launchConfigList := []*agentpb.AppLaunchConfig{}
-		a, err := s.agentHandeler.GetAgent(cluster.ClusterID)
+		a, err := s.agentHandeler.GetAgent(orgId, cluster.ClusterID)
 		if err != nil {
 			s.log.Errorf("failed to connect to agent for cluster %s, %v", cluster.ClusterID, err)
 		} else {
@@ -261,7 +261,7 @@ func (s *Server) GetCluster(ctx context.Context, request *serverpb.GetClusterReq
 	}
 
 	s.log.Infof("[org: %s] GetCluster request recieved for cluster %s", orgId, request.ClusterID)
-	clusterDetails, err := s.serverStore.GetClusterDetails(request.ClusterID)
+	clusterDetails, err := s.serverStore.GetClusterDetails(orgId, request.ClusterID)
 	if err != nil {
 		s.log.Errorf("[org: %s] failed to get cluster %s, %v", orgId, request.ClusterID, err)
 		return &serverpb.GetClusterResponse{
@@ -270,7 +270,7 @@ func (s *Server) GetCluster(ctx context.Context, request *serverpb.GetClusterReq
 		}, err
 	}
 
-	a, err := s.agentHandeler.GetAgent(request.ClusterID)
+	a, err := s.agentHandeler.GetAgent(orgId, request.ClusterID)
 	if err != nil {
 		s.log.Error("failed to connect to agent", err)
 		return &serverpb.GetClusterResponse{

--- a/server/pkg/api/store_apps.go
+++ b/server/pkg/api/store_apps.go
@@ -245,7 +245,7 @@ func (s *Server) GetStoreAppValues(ctx context.Context, request *serverpb.GetSto
 		}, nil
 	}
 
-	overrideValues, err := s.replaceGlobalValues(request.ClusterID, decodeBase64StringToBytes(string(marshaledOverride)))
+	overrideValues, err := s.replaceGlobalValues(orgId, request.ClusterID, decodeBase64StringToBytes(string(marshaledOverride)))
 	if err != nil {
 		s.log.Errorf("failed to update overrided store app values, %v", err)
 		return &serverpb.GetStoreAppValuesResponse{
@@ -261,8 +261,8 @@ func (s *Server) GetStoreAppValues(ctx context.Context, request *serverpb.GetSto
 	}, nil
 }
 
-func (s *Server) replaceGlobalValues(clusterID string, overridedValues []byte) ([]byte, error) {
-	agent, err := s.agentHandeler.GetAgent(clusterID)
+func (s *Server) replaceGlobalValues(orgId, clusterID string, overridedValues []byte) ([]byte, error) {
+	agent, err := s.agentHandeler.GetAgent(orgId, clusterID)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to initialize agent for cluster %s", clusterID)
 	}
@@ -377,7 +377,7 @@ func (s *Server) DeployStoreApp(ctx context.Context, request *serverpb.DeploySto
 		},
 	}
 
-	agent, err := s.agentHandeler.GetAgent(request.ClusterID)
+	agent, err := s.agentHandeler.GetAgent(orgId, request.ClusterID)
 	if err != nil {
 		s.log.Errorf("failed to initialize agent, %v", err)
 		return &serverpb.DeployStoreAppResponse{

--- a/server/pkg/store/astra/cluster_store.go
+++ b/server/pkg/store/astra/cluster_store.go
@@ -10,10 +10,10 @@ import (
 
 const (
 	insertClusterQuery     = "INSERT INTO %s.capten_clusters (cluster_id, org_id, cluster_name, endpoint) VALUES (%s, %s, '%s', '%s');"
-	updateClusterQuery     = "UPDATE %s.capten_clusters SET cluster_name='%s', endpoint='%s' WHERE cluster_id=%s AND org_id=%s;"
-	deleteClusterQuery     = "DELETE FROM %s.capten_clusters WHERE cluster_id=%s AND org_id=%s;"
-	getClusterDetailsQuery = "SELECT org_id, cluster_id, cluster_name, endpoint FROM %s.capten_clusters WHERE cluster_id=%s;"
-	getClustersForOrgQuery = "SELECT org_id, cluster_id, cluster_name, endpoint FROM %s.capten_clusters WHERE org_id=%s ALLOW FILTERING;"
+	updateClusterQuery     = "UPDATE %s.capten_clusters SET cluster_name='%s', endpoint='%s' WHERE org_id=%s AND cluster_id=%s;"
+	deleteClusterQuery     = "DELETE FROM %s.capten_clusters WHERE org_id=%s AND cluster_id=%s;"
+	getClusterDetailsQuery = "SELECT org_id, cluster_id, cluster_name, endpoint FROM %s.capten_clusters WHERE org_id=%s AND cluster_id=%s;"
+	getClustersForOrgQuery = "SELECT org_id, cluster_id, cluster_name, endpoint FROM %s.capten_clusters WHERE org_id=%s;"
 )
 
 func (a *AstraServerStore) AddCluster(orgID, clusterID, clusterName, endpoint string) error {
@@ -30,7 +30,7 @@ func (a *AstraServerStore) AddCluster(orgID, clusterID, clusterName, endpoint st
 
 func (a *AstraServerStore) UpdateCluster(orgID, clusterID, clusterName, endpoint string) error {
 	q := &pb.Query{
-		Cql: fmt.Sprintf(updateClusterQuery, a.keyspace, clusterName, endpoint, clusterID, orgID),
+		Cql: fmt.Sprintf(updateClusterQuery, a.keyspace, clusterName, endpoint, orgID, clusterID),
 	}
 
 	_, err := a.c.Session().ExecuteQuery(q)
@@ -42,7 +42,7 @@ func (a *AstraServerStore) UpdateCluster(orgID, clusterID, clusterName, endpoint
 
 func (a *AstraServerStore) DeleteCluster(orgID, clusterID string) error {
 	q := &pb.Query{
-		Cql: fmt.Sprintf(deleteClusterQuery, a.keyspace, clusterID, orgID),
+		Cql: fmt.Sprintf(deleteClusterQuery, a.keyspace, orgID, clusterID),
 	}
 
 	_, err := a.c.Session().ExecuteQuery(q)
@@ -52,9 +52,9 @@ func (a *AstraServerStore) DeleteCluster(orgID, clusterID string) error {
 	return nil
 }
 
-func (a *AstraServerStore) GetClusterDetails(clusterID string) (*types.ClusterDetails, error) {
+func (a *AstraServerStore) GetClusterDetails(orgID, clusterID string) (*types.ClusterDetails, error) {
 	q := &pb.Query{
-		Cql: fmt.Sprintf(getClusterDetailsQuery, a.keyspace, clusterID),
+		Cql: fmt.Sprintf(getClusterDetailsQuery, a.keyspace, orgID, clusterID),
 	}
 
 	response, err := a.c.Session().ExecuteQuery(q)

--- a/server/pkg/store/astra/type.go
+++ b/server/pkg/store/astra/type.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	createKeyspaceQuery             = "CREATE KEYSPACE IF NOT EXISTS %s WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1};"
-	createClusterEndpointTableQuery = "CREATE TABLE IF NOT EXISTS %s.capten_clusters (cluster_id uuid, org_id uuid, cluster_name text, endpoint text, PRIMARY KEY (cluster_id, org_id));"
+	createClusterEndpointTableQuery = "CREATE TABLE IF NOT EXISTS %s.capten_clusters (cluster_id uuid, org_id uuid, cluster_name text, endpoint text, PRIMARY KEY (org_id, cluster_id));"
 	createAppConfigTableQuery       = "CREATE TABLE IF NOT EXISTS %s.store_app_config(id TEXT, created_time timestamp, last_updated_time timestamp, last_updated_user TEXT, name TEXT, chart_name TEXT, repo_name TEXT, release_name TEXT, repo_url TEXT, namespace TEXT, version TEXT, create_namespace BOOLEAN, privileged_namespace BOOLEAN, launch_ui_url TEXT, launch_ui_redirect_url TEXT, category TEXT, icon TEXT, description TEXT, launch_ui_values TEXT, override_values TEXT, template_values TEXT, PRIMARY KEY (name, version));"
 )
 

--- a/server/pkg/store/store.go
+++ b/server/pkg/store/store.go
@@ -10,7 +10,7 @@ import (
 
 type ServerStore interface {
 	InitializeDb() error
-	GetClusterDetails(clusterID string) (*types.ClusterDetails, error)
+	GetClusterDetails(orgID, clusterID string) (*types.ClusterDetails, error)
 	GetClusters(orgID string) ([]types.ClusterDetails, error)
 	AddCluster(orgID, clusterID, clusterName, endpoint string) error
 	UpdateCluster(orgID, clusterID, clusterName, endpoint string) error


### PR DESCRIPTION
Currently we don't have any data in the capten_clusters table, So without migration we can change the schema by dropping the table and lets the code re-create it.

To fetch the query based on orgID is it good to keep the partition based on the orgId. So it improves the query performance.